### PR TITLE
fix: reduce `font-weight` and `font-size` in header

### DIFF
--- a/cmd/static/style.css
+++ b/cmd/static/style.css
@@ -39,9 +39,8 @@ header {
 }
 
 header h2 {
-    /*font-size: 1.5rem;*/
-    font-size: xx-large;
-    /*font-weight: 300;*/
+    font-size: 1.25rem;
+    line-height: 1.75rem;
     font-family: 'Roboto', sans-serif;
 }
 


### PR DESCRIPTION
I copied the CSS from the `.text-xl` class in ahb-tabellen/tailwind
