### PR TITLE
fix(ui): Use same heading `"ID-Generator"` on all pages

### DIFF
--- a/cmd/static/templates/malo.tmpl.html
+++ b/cmd/static/templates/malo.tmpl.html
@@ -40,7 +40,7 @@
 {{ .recruitingMessage }}
 <!-- We pass the HTML comment / recruiting ad as a parameter because the HTML comment was stripped from the template -->
 <header>
-    <h2>MarktlokationsId-Generator</h2>
+    <h2>ID-Generator</h2>
 </header>
 
 <main>

--- a/cmd/static/templates/melo.tmpl.html
+++ b/cmd/static/templates/melo.tmpl.html
@@ -40,7 +40,7 @@
 {{ .recruitingMessage }}
 <!-- We pass the HTML comment / recruiting ad as a parameter because the HTML comment was stripped from the template -->
 <header>
-    <h2>MesslokationsId-Generator</h2>
+    <h2>ID-Generator</h2>
 </header>
 
 <main>

--- a/cmd/static/templates/nelo.tmpl.html
+++ b/cmd/static/templates/nelo.tmpl.html
@@ -40,7 +40,7 @@
 {{ .recruitingMessage }}
 <!-- We pass the HTML comment / recruiting ad as a parameter because the HTML comment was stripped from the template -->
 <header>
-    <h2>NetzlokationsId-Generator</h2>
+    <h2>ID-Generator</h2>
 </header>
 
 <main>

--- a/cmd/static/templates/srid.tmpl.html
+++ b/cmd/static/templates/srid.tmpl.html
@@ -40,7 +40,7 @@
 {{ .recruitingMessage }}
 <!-- We pass the HTML comment / recruiting ad as a parameter because the HTML comment was stripped from the template -->
 <header>
-    <h2>Steuerbare Ressource Id-Generator</h2>
+    <h2>ID-Generator</h2>
 </header>
 
 <main>

--- a/cmd/static/templates/trid.tmpl.html
+++ b/cmd/static/templates/trid.tmpl.html
@@ -40,7 +40,7 @@
 {{ .recruitingMessage }}
 <!-- We pass the HTML comment / recruiting ad as a parameter because the HTML comment was stripped from the template -->
 <header>
-    <h2>Technische Ressource Id-Generator</h2>
+    <h2>ID-Generator</h2>
 </header>
 
 <main>


### PR DESCRIPTION
instead of using different titles with different length
fixes #178
